### PR TITLE
CSPACE-4852: Stop hiding searchFields, so button positioning works.

### DIFF
--- a/src/main/webapp/defaults/js/AdvancedSearch.js
+++ b/src/main/webapp/defaults/js/AdvancedSearch.js
@@ -205,12 +205,6 @@ cspace = cspace || {};
             afterFetch: function (options) {
                 that.initSearchFields(options);
             },
-            recordTypeChanged: function () {
-                that.locate("searchFields").hide();
-            },
-            afterSearchFieldsInit: function () {
-                that.locate("searchFields").show();
-            },
             onSearch: function (searchModel) {
                 that.toggleControls(true);
             },


### PR DESCRIPTION
Here's a patch for CSPACE-4852. The searchFields component was being hidden when the initDependent call was made, so button positioning didn't work. But hiding seems unnecessary, so simply not doing it fixes this.
