### PR TITLE
CSPACE-5599: Changing label selector for Acquisition Source field in Acq...

### DIFF
--- a/src/main/webapp/defaults/bundle/core-messages.properties
+++ b/src/main/webapp/defaults/bundle/core-messages.properties
@@ -375,7 +375,7 @@ contact-telephoneNumberTypeLabel: Type
 #Acquisition:
 acquisition-ownersLabel: Owner
 acquisition-acquisitionFundingLabel: Acquisition Funding
-acquisition-acquisitionSourcesLabel: Acquisition Source
+acquisition-acquisitionSourceLabel: Acquisition Source
 acquisition-objectCollectionInformationLabel: Object Collection Information
 acquisition-acquisitionProvisosLabel: Acquisition Provisos
 acquisition-acquisitionAuthorizerLabel: Acquisition Authorizer
@@ -413,7 +413,6 @@ acquisition-updatedAtLabel: Modified Date
 acquisition-updatedAtStartLabel: Earliest
 acquisition-updatedAtEndLabel: Latest
 acquisition-editNameLabel: Record Modified By
-acquisition-acquisitionSourceLabel: Source
 acquisition-ownersourceLabel: 
 acquisition-tenantIDLabel: 
 acquisition-createdAtLabel: 

--- a/src/main/webapp/defaults/html/pages/AcquisitionTemplate.html
+++ b/src/main/webapp/defaults/html/pages/AcquisitionTemplate.html
@@ -71,7 +71,7 @@
 
 				<div class="info-pair">
 					<div class="header">
-						<div class="label csc-acquisition-acquisitionSources-label"></div>
+						<div class="label csc-acquisition-acquisitionSource-label"></div>
 					</div>
 					<div class="content">
 						<input type="text" class="csc-acquisition-acquisitionSource" />


### PR DESCRIPTION
...uisitionTemplate.html from acquisition-acquisitionSources-label to acquistion-acquisitionSource-label. Modifying equivalent selector in core-messages.properties to match, and removing a second acquisition-acquisitionSourceLabel selector that had been set, ambiguously, to 'Source.'

YUra/Alexey - please merge into master. I notice that three UI test suites fail, but none seem related to this work. The failing suites are:

Autocomplete Test Suite (blur-related)
RecordEditor Test Suite
StructuredDate Test Suite (blur-related).

Thanks,
Rick
