### PR TITLE
CSPACE-5616: Fixing core message value on LMI (movement) list heading fo...

### DIFF
--- a/src/main/webapp/defaults/bundle/core-messages.properties
+++ b/src/main/webapp/defaults/bundle/core-messages.properties
@@ -199,7 +199,7 @@ group-updatedByLabel: Record last modified by
 group-identificationNumberRequired: Please specify a Title
 
 movement: Location/Movement/Inventory
-movement-number: Current Location
+movement-number: Reference Number
 media: Media Handling
 media-number: Identification Number
 persontest1: Person Test 1


### PR DESCRIPTION
...r number

Simple fix; ran UI tests anyway. All passed except one: Record Editor Test Suite tests 9&10: Test-delete-confirmation text - media only, and ... no media and no related. Don't see that the failures would be related to my change.

Please merge into master.
