### PR TITLE
CSPACE-5758: Adding computedCurrentLocation field to CatalogingTemplate,...

### DIFF
--- a/src/main/webapp/defaults/bundle/core-messages.properties
+++ b/src/main/webapp/defaults/bundle/core-messages.properties
@@ -1071,6 +1071,7 @@ collection-object-dateLatestDayLabel: Day, Latest Date
 collection-object-dateLatestQualifierValueLabel: Latest Date Qualifier Value
 collection-object-numberOfObjectsStartLabel: Minimum
 collection-object-numberOfObjectsEndLabel: Maximum
+collection-object-computedCurrentLocationLabel: Computed Current Location
 
 #Record groups:
 vocabularies: Vocabularies

--- a/src/main/webapp/defaults/html/pages/CatalogingTemplate.html
+++ b/src/main/webapp/defaults/html/pages/CatalogingTemplate.html
@@ -98,6 +98,14 @@
 						<textarea rows="4" cols="30" class="input-textarea csc-object-identification-comments"></textarea>
 					</div>
 				</div>
+                                <div class="info-pair">
+					<div class="header">
+						<div class="label csc-collection-object-computedCurrentLocation-label"></div>
+					</div>
+					<div class="content">
+                                            <input type="text" disabled="disabled" class="csc-collection-object-computedCurrentLocation"/>
+					</div>
+				</div>
 			</div>
 		</div>
 		


### PR DESCRIPTION
... adding field label to core-messages.

Yura - 

Here's the UI work I did to see my services and app-layer changes (CSPACE-5756 and -5757, respectively). You may want to use it. All UI tests pass.

One thing: the value displayed in the readonly computedCurrentLocation field is a refName. The display name portion of the refName is obscured off the right-hand edge of the text box, so the display is pretty useless and ugly to boot. (I've uploaded a screenshot to CSPACE-5728. You can access it here:
http://issues.collectionspace.org/secure/attachment/15474/CSPACE-5728_refName-in-readonly-computedCurrentLocation-field.png.) 

Can you make that better? Let me know if I need to change the app layer config at all.

Thanks,
Rick
