### PR TITLE
CSPACE-4803: adding in 'clearfix' selector for repeatable elements since...

### DIFF
--- a/src/main/webapp/defaults/css/repeatable.css
+++ b/src/main/webapp/defaults/css/repeatable.css
@@ -280,3 +280,6 @@ div.info-pair-date li.cs-repeatable-repeat {
     display:inline-block;
     height:19px;
 }
+.cs-fixedExternalURL .cs-repeatable-group li.cs-repeatable-repeat.clearfix:after {
+   content: "";
+}

--- a/src/main/webapp/defaults/js/Repeatable.js
+++ b/src/main/webapp/defaults/js/Repeatable.js
@@ -150,6 +150,7 @@ cspace = cspace || {};
             add: "cs-repeatable-add",
             repeatable: "cs-repeatable",
             repeat: "cs-repeatable-repeat",
+            clearfix: "clearfix",
             "delete": "cs-repeatable-delete",
             primary: "cs-repeatable-primary",
             content: "cs-repeatable-content",
@@ -464,6 +465,7 @@ cspace = cspace || {};
                        .addClass(getStyle("content"))
                        .wrap($("<ul></ul>").addClass(getStyle("repeatable")))
                        .wrap($("<li/>").addClass(getClass("repeat"))
+                                       .addClass(getStyle("clearfix"))
                                        .addClass(getStyle("repeat"))
                                        .addClass(getStyle("show")))
                        .parent("li");


### PR DESCRIPTION
... this breaks padding issues. Work-around in place for hierarchical repeating elements that don't play well with the 'clearfix' selector's use of   content:'.';
