### PR TITLE
CSPACE-5904: Exclude narrower contexts (e.g. narrower authority terms, o...

### DIFF
--- a/src/main/webapp/defaults/config/cataloging.json
+++ b/src/main/webapp/defaults/config/cataloging.json
@@ -10,7 +10,7 @@
                             "identificationNumber": ".csc-object-identification-object-number" 
                         },
                         "uispec": "{pageBuilder}.options.uispec.recordEditor",
-                        "fieldsToIgnore": ["csid", "fields.csid", "fields.objectNumber"]
+                        "fieldsToIgnore": ["csid", "fields.csid", "fields.objectNumber", "fields.narrowerContexts"]
                     }
                 },
                 "titleBar": {

--- a/src/main/webapp/defaults/config/concept.json
+++ b/src/main/webapp/defaults/config/concept.json
@@ -10,7 +10,8 @@
                         "fieldsToIgnore": [
                             "csid",
                             "fields.csid",
-                            "fields.shortIdentifier"
+                            "fields.shortIdentifier",
+                            "fields.narrowerContexts"
                         ],
                         "selectors": {
                             "identificationNumber": ".csc-conceptAuthority-termDisplayName"

--- a/src/main/webapp/defaults/config/location.json
+++ b/src/main/webapp/defaults/config/location.json
@@ -7,7 +7,7 @@
                     "type":  "cspace.recordEditor",
                     "options": {
                         "uispec": "{pageBuilder}.options.uispec.recordEditor",
-                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier"],
+                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier", "fields.narrowerContexts"],
                         "selectors": {
                             "identificationNumber": ".csc-locationAuthority-termDisplayName"
                         }

--- a/src/main/webapp/defaults/config/organization.json
+++ b/src/main/webapp/defaults/config/organization.json
@@ -10,7 +10,7 @@
                             "identificationNumber": ".csc-organizationAuthority-termDisplayName"
                         },
                         "uispec": "{pageBuilder}.options.uispec.recordEditor",
-                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier"]
+                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier", "fields.narrowerContexts"]
                     }
                 },
                 "titleBar": {

--- a/src/main/webapp/defaults/config/person.json
+++ b/src/main/webapp/defaults/config/person.json
@@ -10,7 +10,7 @@
                             "identificationNumber": ".csc-personAuthority-termDisplayName"
                         },
                         "uispec": "{pageBuilder}.options.uispec.recordEditor",
-                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier"]
+                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier", "fields.narrowerContexts"]
                     }
                 },
                 "titleBar": {

--- a/src/main/webapp/defaults/config/place.json
+++ b/src/main/webapp/defaults/config/place.json
@@ -7,7 +7,7 @@
                     "type":  "cspace.recordEditor",
                     "options": {
                         "uispec": "{pageBuilder}.options.uispec.recordEditor",
-                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier"],
+                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier", "fields.narrowerContexts"],
                         "selectors": {
                             "identificationNumber": ".csc-placeAuthority-termDisplayName"
                         }

--- a/src/main/webapp/tenants/lifesci/config/cataloging.json
+++ b/src/main/webapp/tenants/lifesci/config/cataloging.json
@@ -10,7 +10,7 @@
                             "identificationNumber": ".csc-object-identification-object-number" 
                         },
                         "uispec": "{pageBuilder}.options.uispec.recordEditor",
-                        "fieldsToIgnore": ["csid", "fields.csid", "fields.objectNumber"]
+                        "fieldsToIgnore": ["csid", "fields.csid", "fields.objectNumber", "fields.narrowerContexts"]
                     }
                 },
                 "titleBar": {

--- a/src/main/webapp/tenants/lifesci/config/taxon.json
+++ b/src/main/webapp/tenants/lifesci/config/taxon.json
@@ -10,7 +10,7 @@
                             "identificationNumber": ".csc-taxonAuthority-termDisplayName"
                         },
                         "uispec": "{pageBuilder}.options.uispec.recordEditor",
-                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier"]
+                        "fieldsToIgnore": ["csid", "fields.csid", "fields.shortIdentifier", "fields.narrowerContexts"]
                     }
                 },
                 "titleBar": {


### PR DESCRIPTION
...bject components) from being copied over when 'cloning' a record via Create New From Existing.
