### PR TITLE
CSPACE-5869: Set limit of 40 media items returned in media snapshot, for...

### DIFF
--- a/src/main/webapp/defaults/js/MediaView.js
+++ b/src/main/webapp/defaults/js/MediaView.js
@@ -82,7 +82,7 @@ cspace = cspace || {};
                 }
             })
         },
-        relatedMediaUrl: cspace.componentUrlBuilder("%tenant/%tname/%primary/media/%csid?pageNum=0&pageSize=0")
+        relatedMediaUrl: cspace.componentUrlBuilder("%tenant/%tname/%primary/media/%csid?pageNum=0&pageSize=40")
     });
 
     // Render tree for the MediaView


### PR DESCRIPTION
... safety.

Log statements after sample load reflect change to Mediaview.js, show no untoward behavior in response:
{code}
127.0.0.1 - - [13/May/2013:11:51:24 -0700] "GET /cspace-services/media?pgSz=40&pgNum=0&rtSbj=ffc5ca6b-a9c9-4aaa-9981&wf_deleted=false HTTP/1.1" 200 1118
0:0:0:0:0:0:0:1 - - [13/May/2013:11:51:24 -0700] "GET /collectionspace/tenant/core/cataloging/media/ffc5ca6b-a9c9-4aaa-9981?pageNum=0&pageSize=40 HTTP/1.1" 200 1080
{code}
