### PR TITLE
Materials profile material authority advanced search updates

### DIFF
--- a/src/main/webapp/defaults/css/cspace.css
+++ b/src/main/webapp/defaults/css/cspace.css
@@ -2219,6 +2219,17 @@ input[type=button].cs-mediaUploader-removeMedia:focus {
     border-radius:4px;
     display: none;
 }
+.csc-advancedsearch-container .cs-multipleEdit .tablegroupfix .content {
+    width: 86%;
+}
+.csc-advancedsearch-container .cs-multipleEdit input[type="button"].cs-repeatable-add {
+    top: 0;
+}
+.csc-advancedsearch-container .tablegroupfix .cs-repeatable-group li {
+    border: none;
+    background-color: inherit;
+    padding: 0px !important;
+}
 
 .cs-searchTips-template {
     margin: 0 20px;

--- a/src/main/webapp/defaults/html/components/SearchFieldsTemplate-material.html
+++ b/src/main/webapp/defaults/html/components/SearchFieldsTemplate-material.html
@@ -58,14 +58,22 @@
                             </div>
                             <div class="info-column">
                                 <div class="info-column2-50 fl-force-left">
-                                    <div class="info-pair">
+                                    <div class="info-pair tablegroupfix">
                                         <div class="header">
-                                            <div class="label csc-material-termLanguage-label"></div>
+                                            <div class="label csc-material-materialTermAttributionContributingOrganization-label"></div>
                                         </div>
-                                        <div class="content clearfix">
-                                            <select class="csc-materialAuthority-termLanguage input-select">
-                                                <option value="">Options not loaded</option>
-                                            </select>
+                                        <div class="content clearfix csc-material-materialTermAttributionContributingGroup">
+                                            <input type="text" class="csc-material-materialTermAttributionContributingOrganization"/>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="info-column2-50 fl-force-right">
+                                    <div class="info-pair tablegroupfix">
+                                        <div class="header">
+                                            <div class="label csc-material-materialTermAttributionContributingPerson-label"></div>
+                                        </div>
+                                        <div class="content clearfix csc-material-materialTermAttributionContributingGroup">
+                                            <input type="text" class="csc-material-materialTermAttributionContributingPerson"/>
                                         </div>
                                     </div>
                                 </div>
@@ -81,28 +89,28 @@
                         <select class="csc-material-materialRecordType input-select"><option value="">Options not loaded</option></select>
                     </div>
                 </div> -->
-                <div class="info-pair">
+                <div class="info-pair tablegroupfix">
                     <div class="header">
-                        <div class="label csc-material-familyName-label"></div>
+                        <div class="label csc-material-materialCompositionFamilyName-label"></div>
                     </div>
-                    <div class="content clearfix">
-                        <input type="text" class="csc-material-familyName"/>
+                    <div class="content clearfix csc-material-materialCompositionGroup">
+                        <input type="text" class="csc-material-materialCompositionFamilyName"/>
                     </div>
                 </div>
-                <div class="info-pair">
+                <div class="info-pair tablegroupfix">
                     <div class="header">
-                        <div class="label csc-material-className-label"></div>
+                        <div class="label csc-material-materialCompositionClassName-label"></div>
                     </div>
-                    <div class="content clearfix">
-                        <input type="text" class="csc-material-className"/>
+                    <div class="content clearfix csc-material-materialCompositionGroup">
+                        <input type="text" class="csc-material-materialCompositionClassName"/>
                     </div>
                 </div>
-                <div class="info-pair">
+                <div class="info-pair tablegroupfix">
                     <div class="header">
-                        <div class="label csc-material-genericName-label"></div>
+                        <div class="label csc-material-materialCompositionGenericName-label"></div>
                     </div>
-                    <div class="content clearfix">
-                        <input type="text" class="csc-material-genericName"/>
+                    <div class="content clearfix csc-material-materialCompositionGroup">
+                        <input type="text" class="csc-material-materialCompositionGenericName"/>
                     </div>
                 </div>
                 <div class="info-pair-select">


### PR DESCRIPTION
Added a class "tablegroupfix" and some CSS to standardize the
appearance of fields in advanced search that are embedded in
a table in the primary page (did not find a precedent for this).